### PR TITLE
Flooftier Outpost -> Redwater Outpost | Ingame rules change.

### DIFF
--- a/Resources/Maps/_NF/Outpost/frontier.yml
+++ b/Resources/Maps/_NF/Outpost/frontier.yml
@@ -35,7 +35,7 @@ entities:
   - uid: 2173
     components:
     - type: MetaData
-      name: Flooftier Outpost
+      name: Redwater Outpost
     - type: Transform
       parent: 5691
     - type: MapGrid

--- a/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
+++ b/Resources/Prototypes/_NF/Maps/Outpost/frontier.yml
@@ -1,6 +1,6 @@
 - type: gameMap
   id: Frontier
-  mapName: 'Flooftier Outpost'
+  mapName: 'Redwater Outpost'
   mapPath: /Maps/_NF/Outpost/frontier.yml
   minPlayers: 0
   maxPlayers: 100
@@ -11,7 +11,7 @@
       stationProto: StandardFrontierStation
       components:
         - type: StationNameSetup
-          mapNameTemplate: 'Flooftier Outpost'
+          mapNameTemplate: 'Redwater Outpost'
 #          nameGenerator:
 #            !type:NanotrasenNameGenerator
 #            prefixCreator: '14'

--- a/Resources/ServerInfo/_NF/Guidebook/Rules/Zero_Tolerance.xml
+++ b/Resources/ServerInfo/_NF/Guidebook/Rules/Zero_Tolerance.xml
@@ -3,7 +3,7 @@
 
 The rules below are absolute. Players caught violating them may be banned without prior warning.
 
-  - Players must be at least 18 years of age to play on Flooftier Station servers. Any player under 18 years old will be banned until they are of age.
+  - Players must be at least 18 years of age to play on Flooftier Station servers. Any player under 18 years old will be banned permanently.
   - End of round griefing (EORG) is not permitted and will result in an immediate 3 hour ban.
   - Absolutely no hate speech, including slurs, bigotry, racism, specism (demeaning other characters in-game due to their in-game race), sexism, or ableism.
 


### PR DESCRIPTION
## About the PR
see changes


## Why / Balance
further differentiates us from floof/fron tier
minors should not come back

## How to test
look in game maybe

## Requirements
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**

:cl:
- add: Added fun!
- tweak: flooftier outpost -> redwater outpost
- tweak: minors will be banned forever
:/cl:
