### PR TITLE
Relace gas sales from Edison over to the games Cargo Depos

### DIFF
--- a/Resources/Maps/_NF/POI/cargodepot.yml
+++ b/Resources/Maps/_NF/POI/cargodepot.yml
@@ -19,7 +19,6 @@ entities:
     components:
     - type: MetaData
     - type: Transform
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -48,11 +47,6 @@ entities:
           version: 6
     - type: Broadphase
     - type: Physics
-      bodyStatus: InAir
-      angularDamping: 0.05
-      linearDamping: 0.05
-      fixedRotation: False
-      bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
     - type: OccluderTree

--- a/Resources/Maps/_NF/POI/cargodepot.yml
+++ b/Resources/Maps/_NF/POI/cargodepot.yml
@@ -19,6 +19,7 @@ entities:
     components:
     - type: MetaData
     - type: Transform
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -47,6 +48,11 @@ entities:
           version: 6
     - type: Broadphase
     - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
     - type: OccluderTree
@@ -961,20 +967,10 @@ entities:
     - type: Transform
       pos: 5.5,10.5
       parent: 10
-  - uid: 1037
-    components:
-    - type: Transform
-      pos: -7.5,6.5
-      parent: 10
   - uid: 1038
     components:
     - type: Transform
       pos: 8.5,6.5
-      parent: 10
-  - uid: 1039
-    components:
-    - type: Transform
-      pos: 8.5,-5.5
       parent: 10
   - uid: 1040
     components:
@@ -3467,10 +3463,6 @@ entities:
     - type: Transform
       pos: 0.5,-0.5
       parent: 10
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          ents: []
 - proto: ComputerPalletConsoleNFHighMarket
   entities:
   - uid: 7
@@ -3815,6 +3807,20 @@ entities:
       parent: 10
     - type: Fixtures
       fixtures: {}
+- proto: Gaslock
+  entities:
+  - uid: 184
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,0.5
+      parent: 10
+  - uid: 469
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,0.5
+      parent: 10
 - proto: GasMixerOn
   entities:
   - uid: 290
@@ -3855,6 +3861,18 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 841
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 10
+  - uid: 842
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,0.5
+      parent: 10
   - uid: 843
     components:
     - type: Transform
@@ -3935,6 +3953,74 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 478
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 10
+  - uid: 479
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 10
+  - uid: 480
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 10
+  - uid: 481
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 10
+  - uid: 482
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,0.5
+      parent: 10
+  - uid: 483
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,0.5
+      parent: 10
+  - uid: 484
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,0.5
+      parent: 10
+  - uid: 485
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -11.5,0.5
+      parent: 10
+  - uid: 513
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,0.5
+      parent: 10
+  - uid: 618
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,0.5
+      parent: 10
+  - uid: 619
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,0.5
+      parent: 10
+  - uid: 840
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 10
   - uid: 869
     components:
     - type: Transform
@@ -4812,6 +4898,18 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 474
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-3.5
+      parent: 10
+  - uid: 475
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,4.5
+      parent: 10
   - uid: 872
     components:
     - type: Transform
@@ -4930,6 +5028,18 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 470
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 10
+  - uid: 471
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 10
 - proto: GasPressurePumpOnMax
   entities:
   - uid: 446
@@ -4939,6 +5049,44 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#990000FF'
+- proto: GasSaleConsole
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 10
+  - uid: 468
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-5.5
+      parent: 10
+- proto: GasSalePoint
+  entities:
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 10
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-5.5
+      parent: 10
+- proto: GasValve
+  entities:
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 10
+  - uid: 477
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 10
 - proto: GasVentPump
   entities:
   - uid: 844
@@ -5066,6 +5214,19 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#990000FF'
+- proto: GasVolumePump
+  entities:
+  - uid: 472
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,5.5
+      parent: 10
+  - uid: 473
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 10
 - proto: GeneratorBasic15kW
   entities:
   - uid: 296
@@ -5244,12 +5405,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -12.5,-2.5
       parent: 10
-  - uid: 180
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,0.5
-      parent: 10
   - uid: 181
     components:
     - type: Transform
@@ -5261,12 +5416,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,0.5
-      parent: 10
-  - uid: 187
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,0.5
       parent: 10
   - uid: 198
     components:
@@ -6130,23 +6279,11 @@ entities:
     - type: Transform
       pos: 0.5,7.5
       parent: 10
-  - uid: 182
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,0.5
-      parent: 10
   - uid: 183
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,0.5
-      parent: 10
-  - uid: 184
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,0.5
       parent: 10
   - uid: 185
     components:

--- a/Resources/Maps/_NF/POI/cargodepotalt.yml
+++ b/Resources/Maps/_NF/POI/cargodepotalt.yml
@@ -19,6 +19,7 @@ entities:
     components:
     - type: MetaData
     - type: Transform
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -47,6 +48,11 @@ entities:
           version: 6
     - type: Broadphase
     - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
     - type: OccluderTree
@@ -1031,20 +1037,10 @@ entities:
     - type: Transform
       pos: 5.5,10.5
       parent: 10
-  - uid: 1037
-    components:
-    - type: Transform
-      pos: -7.5,6.5
-      parent: 10
   - uid: 1038
     components:
     - type: Transform
       pos: 8.5,6.5
-      parent: 10
-  - uid: 1039
-    components:
-    - type: Transform
-      pos: 8.5,-5.5
       parent: 10
   - uid: 1040
     components:
@@ -3530,10 +3526,6 @@ entities:
     - type: Transform
       pos: 0.5,-0.5
       parent: 10
-    - type: ContainerContainer
-      containers:
-        board: !type:Container
-          ents: []
 - proto: ComputerPalletConsoleNFHighMarket
   entities:
   - uid: 7
@@ -3858,6 +3850,20 @@ entities:
       parent: 10
     - type: Fixtures
       fixtures: {}
+- proto: Gaslock
+  entities:
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,0.5
+      parent: 10
+  - uid: 513
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -12.5,0.5
+      parent: 10
 - proto: GasMixerOn
   entities:
   - uid: 290
@@ -3952,6 +3958,18 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 1037
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 10
+  - uid: 1039
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,0.5
+      parent: 10
 - proto: GasPipeFourway
   entities:
   - uid: 876
@@ -4845,6 +4863,74 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 1043
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,0.5
+      parent: 10
+  - uid: 1044
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,0.5
+      parent: 10
+  - uid: 1045
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,0.5
+      parent: 10
+  - uid: 1046
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,0.5
+      parent: 10
+  - uid: 1051
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,0.5
+      parent: 10
+  - uid: 1053
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,0.5
+      parent: 10
+  - uid: 1054
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,0.5
+      parent: 10
+  - uid: 1055
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,0.5
+      parent: 10
+  - uid: 1056
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 10
+  - uid: 1057
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 10
+  - uid: 1058
+    components:
+    - type: Transform
+      pos: -7.5,1.5
+      parent: 10
+  - uid: 1060
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 10
 - proto: GasPipeTJunction
   entities:
   - uid: 293
@@ -4943,6 +5029,18 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 1061
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,4.5
+      parent: 10
+  - uid: 1062
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-3.5
+      parent: 10
 - proto: GasPort
   entities:
   - uid: 294
@@ -4973,6 +5071,18 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 859
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 10
+  - uid: 1013
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-3.5
+      parent: 10
 - proto: GasPressurePumpOnMax
   entities:
   - uid: 446
@@ -4982,6 +5092,44 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#990000FF'
+- proto: GasSaleConsole
+  entities:
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-5.5
+      parent: 10
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 10
+- proto: GasSalePoint
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -7.5,6.5
+      parent: 10
+  - uid: 618
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-5.5
+      parent: 10
+- proto: GasValve
+  entities:
+  - uid: 841
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 10
+  - uid: 842
+    components:
+    - type: Transform
+      pos: -7.5,3.5
+      parent: 10
 - proto: GasVentPump
   entities:
   - uid: 844
@@ -5109,6 +5257,19 @@ entities:
       parent: 10
     - type: AtmosPipeColor
       color: '#990000FF'
+- proto: GasVolumePump
+  entities:
+  - uid: 619
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,5.5
+      parent: 10
+  - uid: 840
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 10
 - proto: GeneratorBasic15kW
   entities:
   - uid: 296
@@ -5287,12 +5448,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -12.5,-2.5
       parent: 10
-  - uid: 180
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,0.5
-      parent: 10
   - uid: 181
     components:
     - type: Transform
@@ -5304,12 +5459,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,0.5
-      parent: 10
-  - uid: 187
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,0.5
       parent: 10
   - uid: 198
     components:
@@ -6180,23 +6329,11 @@ entities:
     - type: Transform
       pos: 0.5,7.5
       parent: 10
-  - uid: 182
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,0.5
-      parent: 10
   - uid: 183
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,0.5
-      parent: 10
-  - uid: 184
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,0.5
       parent: 10
   - uid: 185
     components:

--- a/Resources/Maps/_NF/POI/cargodepotalt.yml
+++ b/Resources/Maps/_NF/POI/cargodepotalt.yml
@@ -19,7 +19,6 @@ entities:
     components:
     - type: MetaData
     - type: Transform
-      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -48,11 +47,6 @@ entities:
           version: 6
     - type: Broadphase
     - type: Physics
-      bodyStatus: InAir
-      angularDamping: 0.05
-      linearDamping: 0.05
-      fixedRotation: False
-      bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
     - type: OccluderTree

--- a/Resources/Maps/_NF/POI/edison.yml
+++ b/Resources/Maps/_NF/POI/edison.yml
@@ -133,6 +133,11 @@ entities:
           version: 6
     - type: Broadphase
     - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
     - type: OccluderTree
@@ -18999,6 +19004,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -6.5,21.5
       parent: 2
+  - uid: 3663
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 2
 - proto: GasPressurePump
   entities:
   - uid: 129
@@ -19092,27 +19103,6 @@ entities:
     components:
     - type: Transform
       pos: -5.5,24.5
-      parent: 2
-- proto: GasSaleConsole
-  entities:
-  - uid: 4274
-    components:
-    - type: Transform
-      pos: -1.5,11.5
-      parent: 2
-  - uid: 4317
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,14.5
-      parent: 2
-- proto: GasSalePoint
-  entities:
-  - uid: 3663
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,12.5
       parent: 2
 - proto: GasThermoMachineFreezer
   entities:

--- a/Resources/Maps/_NF/POI/edison.yml
+++ b/Resources/Maps/_NF/POI/edison.yml
@@ -133,11 +133,6 @@ entities:
           version: 6
     - type: Broadphase
     - type: Physics
-      bodyStatus: InAir
-      angularDamping: 0.05
-      linearDamping: 0.05
-      fixedRotation: False
-      bodyType: Dynamic
     - type: Fixtures
       fixtures: {}
     - type: OccluderTree


### PR DESCRIPTION
Removes Edisons gas sale terminal and port
Adds gas sale terminals and ports to either cargo depo. Also includes gaslocks so ships can unload without shuffling canisters around.
